### PR TITLE
Fix linux script argument handling

### DIFF
--- a/script/linux/faketty
+++ b/script/linux/faketty
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-script -q -e -c "$*"
+script -q -e -c "$(printf "'%s' " "$@")"


### PR DESCRIPTION
You can see the broken behavior wrt argument escaping by running this:

```sh
faketty ls 'a b c'
```

(assume `a b c` does not exist)

Expectation is that you should see a single error message for `a b c does not exist`. Instead, it prints out the current directory (b/c just `ls` is being executed, not `ls 'a b c'`) and then creates `a b c` (idk why `script` does that, it just does).

This PR gives better handling of arguments such that any args should get properly escaped, even if they have spaces.