### PR TITLE
Fix darwin argument passing

### DIFF
--- a/script/darwin/faketty
+++ b/script/darwin/faketty
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-unbuffer $*
+unbuffer "$@"


### PR DESCRIPTION
`faketty ls 'a b c'` should work as expected (trying to list `a b c` folder), but instead the current script will error terribly with:

```
couldn't execute "ls a b c": no such file or directory
    while executing
"spawn -noecho {ls a b c}"
    ("eval" body line 1)
    invoked from within
"eval [list spawn -noecho] $argv"
    invoked from within
"if {[string compare [lindex $argv 0] "-p"] == 0} {
    # pipeline
    set stty_init "-echo"
    eval [list spawn -noecho] [lrange $argv 1 end]
    clo..."
    (file "/usr/local/Cellar/expect/5.45.4_2/libexec/bin/unbuffer" line 13)
```

Similar to #2